### PR TITLE
feat(server): add typed analytics route helpers

### DIFF
--- a/server/src/types/express.ts
+++ b/server/src/types/express.ts
@@ -1,4 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
+import type { ParamsDictionary } from 'express-serve-static-core';
+import type { ParsedQs } from 'qs';
 
 export type UserRole = 'STUDENT' | 'DEVELOPER' | 'TEAM_LEAD' | 'ADMIN';
 
@@ -13,7 +15,26 @@ export interface JWTPayload {
 }
 
 // Extended Request interface for authenticated routes
-export interface AuthenticatedRequest extends Request {
+export type TypedRequest<
+  Params extends ParamsDictionary = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+  Locals extends Record<string, any> = Record<string, any>
+> = Request<Params, ResBody, ReqBody, ReqQuery, Locals>;
+
+export type TypedResponse<
+  ResBody = any,
+  Locals extends Record<string, any> = Record<string, any>
+> = Response<ResBody, Locals>;
+
+export interface AuthenticatedRequest<
+  Params extends ParamsDictionary = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+  Locals extends Record<string, any> = Record<string, any>
+> extends Request<Params, ResBody, ReqBody, ReqQuery, Locals> {
   user: JWTPayload & { id: string };
 }
 
@@ -60,14 +81,46 @@ export type AuthenticatedRouteHandler<T = any> = (
   next?: NextFunction
 ) => Promise<void> | void;
 
+export type TypedRouteHandler<
+  ResBody = any,
+  ReqBody = any,
+  Params extends ParamsDictionary = ParamsDictionary,
+  ReqQuery = ParsedQs,
+  Locals extends Record<string, any> = Record<string, any>
+> = (
+  req: TypedRequest<Params, ResBody, ReqBody, ReqQuery, Locals>,
+  res: TypedResponse<ResBody, Locals>,
+  next: NextFunction
+) => Promise<void> | void;
+
+export type TypedAuthenticatedRouteHandler<
+  ResBody = any,
+  ReqBody = any,
+  Params extends ParamsDictionary = ParamsDictionary,
+  ReqQuery = ParsedQs,
+  Locals extends Record<string, any> = Record<string, any>
+> = (
+  req: AuthenticatedRequest<Params, ResBody, ReqBody, ReqQuery, Locals>,
+  res: TypedResponse<ResBody, Locals>,
+  next: NextFunction
+) => Promise<void> | void;
+
 // Middleware types
 export type Middleware = (req: Request, res: Response, next: NextFunction) => Promise<void> | void;
 
-export type AuthMiddleware = (
-  req: Request,
-  res: Response,
+export type TypedMiddleware<
+  Params extends ParamsDictionary = ParamsDictionary,
+  ResBody = any,
+  ReqBody = any,
+  ReqQuery = ParsedQs,
+  Locals extends Record<string, any> = Record<string, any>
+> = (
+  req: TypedRequest<Params, ResBody, ReqBody, ReqQuery, Locals>,
+  res: TypedResponse<ResBody, Locals>,
   next: NextFunction
 ) => Promise<void> | void;
+
+export type AuthMiddleware = (req: Request, res: Response, next: NextFunction) => Promise<void> | void;
 
 export type ErrorMiddleware = (error: any, req: Request, res: Response, next: NextFunction) => void;
 


### PR DESCRIPTION
## Summary
- introduce typed Express request and response helpers so routes can opt into body, params, and query generics
- tighten analytics route validation by defining explicit payload/query types and Joi schemas backed by the new helpers
- remove `any`/`AuthenticatedRequest` casts from analytics handlers while preserving runtime checks and sanitising validated data

## Testing
- pnpm --filter server type-check *(fails: repository contains pre-existing TypeScript errors outside analytics routes)*

------
https://chatgpt.com/codex/tasks/task_b_68cee081e820832ca4d52452b0b5985f